### PR TITLE
Add stack events listing

### DIFF
--- a/cfncli.gemspec
+++ b/cfncli.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "aws-sdk", "~> 2"
   spec.add_dependency "waiting", "~> 0"
   spec.add_dependency "activesupport", "~> 4"
+  spec.add_dependency "colorize", "~> 0"
 end

--- a/lib/cfncli/cli.rb
+++ b/lib/cfncli/cli.rb
@@ -15,6 +15,7 @@ module CfnCli
 
     # Stack options
     method_option 'stack_name',
+                  alias: '-n',
                   type: :string,
                   required: true,
                   desc: 'Cloudformation stack name'
@@ -115,12 +116,27 @@ module CfnCli
     end
 
     method_option 'stack_name',
+                  alias: '-n',
                   type: :string,
+                  required: true,
                   desc: 'Name or ID of the Cloudformation stack'
+    
+    # Application options
+    method_option 'interval',
+                  type: :numeric,
+                  default: 10,
+                  desc: 'Polling interval (in seconds) for the cloudformation events'
+
+    method_option 'timeout',
+                  type: :numeric,
+                  default: 1800,
+                  desc: 'Timeout (in seconds) for the stack event listing'
+
     desc 'events', 'Displays the events for a stack in realtime'
     def events
       stack_name = options['stack_name']
-      cfn.events(stack_name)
+      config = Config::CfnClient.new(options['interval'], options['retries'])
+      cfn.events(stack_name, config)
     end
 
     no_tasks do

--- a/lib/cfncli/cloudformation.rb
+++ b/lib/cfncli/cloudformation.rb
@@ -41,7 +41,7 @@ module CfnCli
     # List stack events
     def events(stack_name, config)
       stack = create_stack_obj(stack_name, config)
-      stack.list_events(EventPoller.new)
+      stack.list_events(EventPoller.new, config)
     end
 
     # Returns the stack stack

--- a/lib/cfncli/cloudformation.rb
+++ b/lib/cfncli/cloudformation.rb
@@ -1,6 +1,7 @@
 require 'cfncli/cfn_client'
 require 'cfncli/stack'
 require 'cfncli/logger'
+require 'cfncli/event_poller'
 
 require 'waiting'
 require 'pp'
@@ -36,6 +37,12 @@ module CfnCli
       end
       
       stack
+    end
+
+    # List stack events
+    def events(stack_name, config)
+      stack = create_stack_obj(stack_name, config)
+      stack.list_events(EventPoller.new)
     end
 
     # Converts the 'standard' json stack parameters format to the format

--- a/lib/cfncli/cloudformation.rb
+++ b/lib/cfncli/cloudformation.rb
@@ -18,8 +18,7 @@ module CfnCli
     # @param options [Hash] Options for the stack creation 
     #                       (@see http://docs.aws.amazon.com/sdkforruby/api/Aws/CloudFormation/Client.html)
     def create_stack(options, config = nil)
-      stack = create_or_update_stack(options, config)
-      stack.wait_for_completion
+      create_or_update_stack(options, config)
     end
 
     # Creates a stack if it doesn't exist otherwise update it
@@ -43,6 +42,11 @@ module CfnCli
     def events(stack_name, config)
       stack = create_stack_obj(stack_name, config)
       stack.list_events(EventPoller.new)
+    end
+
+    # Returns the stack stack
+    def stack_successful?(stack_name)
+      Stack.new(stack_name).succeeded?
     end
 
     # Converts the 'standard' json stack parameters format to the format

--- a/lib/cfncli/event.rb
+++ b/lib/cfncli/event.rb
@@ -1,0 +1,27 @@
+require 'cfncli/states'
+
+module CfnCli
+  class Event
+    include CfnStates
+
+    attr_reader :event
+
+    def initialize(event)
+      @event = event
+    end
+
+    def status
+      event.resource_status
+    end
+
+    def color
+      return :green if succeeded?
+      return :yellow if in_progress?
+      return :red if failed?
+    end
+
+    def to_s
+      "#{event.timestamp} #{event.resource_status} #{event.resource_type} #{event.logical_resource_id} #{event.resource_status_reason}"
+    end
+  end
+end

--- a/lib/cfncli/event_poller.rb
+++ b/lib/cfncli/event_poller.rb
@@ -1,0 +1,17 @@
+require 'colorize'
+require 'cfncli/event'
+
+module CfnCli
+  class EventPoller
+    def initialize
+    end
+
+    def event(event)
+      colorize Event.new(event)
+    end
+
+    def colorize(event)
+      puts event.to_s.colorize(event.color)
+    end
+  end
+end

--- a/lib/cfncli/event_streamer.rb
+++ b/lib/cfncli/event_streamer.rb
@@ -1,0 +1,34 @@
+module CfnCli
+  class EventStreamer
+    attr_reader :stack
+
+    def initialize(stack)
+      @stack = stack
+      @seen_events = []
+    end
+
+    # Wait for events. This will exit when the
+    # stack reaches a finished state
+    # @yields [CfnEvent] Events for the stack
+    def each_event
+      Waiting.wait do |waiter|
+        next_token = stack.events(next_token).each do |event|
+          yield event unless seen?(event)
+        end
+
+        waiter.done if stack.finished?
+      end
+    end
+
+    private
+
+    attr_accessor :seen_events
+
+    # Indicates if an event has already been seen
+    def seen?(event)
+      res = @seen_events.include? event.id
+      @seen_events << event.id
+      res
+    end
+  end
+end

--- a/lib/cfncli/event_streamer.rb
+++ b/lib/cfncli/event_streamer.rb
@@ -26,8 +26,8 @@ module CfnCli
 
     # Indicates if an event has already been seen
     def seen?(event)
-      res = @seen_events.include? event.id
-      @seen_events << event.id
+      res = seen_events.include? event.id
+      seen_events << event.id
       res
     end
   end

--- a/lib/cfncli/event_streamer.rb
+++ b/lib/cfncli/event_streamer.rb
@@ -1,17 +1,23 @@
 module CfnCli
   class EventStreamer
     attr_reader :stack
+    attr_reader :config
 
-    def initialize(stack)
+    def initialize(stack, config = nil)
       @stack = stack
+      @config = config || default_config
       @seen_events = []
+    end
+
+    def default_config
+      Config::CfnClient.new
     end
 
     # Wait for events. This will exit when the
     # stack reaches a finished state
     # @yields [CfnEvent] Events for the stack
     def each_event
-      Waiting.wait do |waiter|
+      Waiting.wait(interval: config.interval, max_attempts: config.retries) do |waiter|
         next_token = stack.events(next_token).each do |event|
           yield event unless seen?(event)
         end

--- a/lib/cfncli/stack.rb
+++ b/lib/cfncli/stack.rb
@@ -78,8 +78,8 @@ module CfnCli
 
     # List all events in real time
     # @param poller [CfnCli::Poller] Poller class to display events
-    def list_events(poller)
-      streamer = EventStreamer.new(self)
+    def list_events(poller, config = nil)
+      streamer = EventStreamer.new(self, config)
       streamer.each_event do |event|
         poller.event(event)
       end

--- a/lib/cfncli/states.rb
+++ b/lib/cfncli/states.rb
@@ -1,0 +1,72 @@
+module CfnCli
+  module CfnStates
+    # Indicates if the state is finished
+    def finished?
+      finished_states.include? status
+    end
+
+    # Indicates if the state is successful
+    def succeeded?
+      success_states.include? status
+    end
+
+    # Indicates if the state is a transition
+    def in_progress?
+      transitive_states.include? status
+    end
+
+    # Indicates if the state is failed
+    def failed?
+      !succeeded? && !in_progress?
+    end
+
+    # List of possible states
+    def states
+      [
+        'CREATE_IN_PROGRESS',
+        'CREATE_IN_PROGRESS',
+        'CREATE_FAILED',
+        'CREATE_COMPLETE',
+        'ROLLBACK_IN_PROGRESS',
+        'ROLLBACK_FAILED',
+        'ROLLBACK_COMPLETE',
+        'DELETE_IN_PROGRESS',
+        'DELETE_FAILED',
+        'DELETE_COMPLETE',
+        'UPDATE_IN_PROGRESS',
+        'UPDATE_COMPLETE_CLEANUP_IN_PROGRESS',
+        'UPDATE_COMPLETE',
+        'UPDATE_ROLLBACK_IN_PROGRESS',
+        'UPDATE_ROLLBACK_FAILED',
+        'UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS',
+        'UPDATE_ROLLBACK_COMPLETE',
+      ]
+    end
+
+    # List of successful states
+    def success_states
+      [
+        'CREATE_COMPLETE',
+        'DELETE_COMPLETE',
+        'UPDATE_COMPLETE'
+      ]
+    end
+
+    # List of transitive states
+    def transitive_states
+      states.select do |state|
+        state.end_with? 'IN_PROGRESS'
+      end
+    end
+
+    # List of finished states
+    def finished_states
+      states - transitive_states
+    end
+
+    # List of failed or unknown states
+    def failed_states
+      states - success_states - transitive_states
+    end
+  end
+end

--- a/lib/cfncli/version.rb
+++ b/lib/cfncli/version.rb
@@ -1,3 +1,3 @@
 module CfnCli
-  VERSION = "0.1.3"
+  VERSION = "0.2.0"
 end

--- a/spec/lib/cfncli/event_spec.rb
+++ b/spec/lib/cfncli/event_spec.rb
@@ -1,0 +1,36 @@
+require 'cfncli/event'
+
+describe CfnCli::Event do
+  subject(:event) { CfnCli::Event.new(nil) }
+
+  describe '#color' do
+    subject { event.color }
+
+    context 'when the event is successful' do
+      before do
+        expect(event).to receive(:succeeded?).and_return true
+      end
+
+      it { is_expected.to be :green }
+    end
+
+    context 'when the event is in progress' do
+      before do
+        expect(event).to receive(:succeeded?).and_return false
+        expect(event).to receive(:in_progress?).and_return true
+      end
+
+      it { is_expected.to be :yellow }
+    end
+
+    context 'when the event is failed' do
+      before do
+        expect(event).to receive(:succeeded?).and_return false
+        expect(event).to receive(:in_progress?).and_return false
+        expect(event).to receive(:failed?).and_return true
+      end
+
+      it { is_expected.to be :red }
+    end
+  end
+end

--- a/spec/lib/cfncli/event_streamer_spec.rb
+++ b/spec/lib/cfncli/event_streamer_spec.rb
@@ -1,0 +1,31 @@
+require 'cfncli/event_streamer'
+
+describe CfnCli::EventStreamer do
+  subject(:streamer) { CfnCli::EventStreamer.new(nil) }
+
+  describe '#seen?' do
+    subject { streamer.send(:seen?, event) }
+    let(:event) { double CfnCli::Event }
+    let(:event_id) { 'test-id' }
+
+    before do
+      allow(event).to receive(:id).and_return event_id
+    end
+ 
+    context 'when receiving a new event' do
+      before do
+        allow(streamer).to receive(:seen_events).and_return []
+      end
+
+      it { is_expected.to be false }
+    end
+ 
+    context 'when receiving an existing event' do
+      before do
+        allow(streamer).to receive(:seen_events).and_return [event_id]
+      end
+
+      it { is_expected.to be true }
+    end
+  end
+end

--- a/spec/lib/cfncli/state_spec.rb
+++ b/spec/lib/cfncli/state_spec.rb
@@ -1,0 +1,191 @@
+require 'cfncli/states'
+
+describe CfnCli::CfnStates do
+  subject(:state) do
+    class TestState
+      include CfnCli::CfnStates
+    end
+
+    TestState.new
+  end
+
+  describe 'State detection' do
+    before do
+      allow(state).to receive(:status).and_return(stubbed_response)
+    end
+
+    let(:update_complete) { 'UPDATE_COMPLETE' }
+    let(:update_in_progress) { 'UPDATE_IN_PROGRESS' }
+    let(:update_failed) { 'UPDATE_FAILED' }
+
+    describe '#finished?' do
+      subject { state.finished? }
+
+      context 'when in a finished state' do
+        let(:stubbed_response) { update_complete }
+         
+        it { is_expected.to be true }
+      end
+
+      context 'when in a transition state' do
+        let(:stubbed_response) { update_in_progress }
+
+        it { is_expected.to be false }
+      end
+    end
+
+    describe '#succeeded' do
+      subject { state.succeeded? }
+
+      context 'when in a successful state' do
+        let(:stubbed_response) { update_complete }
+
+        it { is_expected.to be true }
+      end
+      
+      context 'when in a transition state' do
+        let(:stubbed_response) { update_in_progress }
+
+        it { is_expected.to be false }
+      end
+      
+      context 'when in a failed state' do
+        let(:stubbed_response) { update_failed }
+
+        it { is_expected.to be false }
+      end
+    end
+
+    describe '#in_progress' do
+      subject { state.in_progress? }
+
+      context 'when in a successful state' do
+        let(:stubbed_response) { update_complete}
+
+        it { is_expected.to be false }
+      end
+      
+      context 'when in a transition state' do
+        let(:stubbed_response) { update_in_progress}
+
+        it { is_expected.to be true }
+      end
+      
+      context 'when in a failed state' do
+        let(:stubbed_response) { update_failed }
+
+        it { is_expected.to be false }
+      end
+    end
+
+    describe '#failed' do
+      subject { state.failed? }
+
+      context 'when in a successful state' do
+        let(:stubbed_response) { update_complete }
+
+        it { is_expected.to be false }
+      end
+      
+      context 'when in a transition state' do
+        let(:stubbed_response) { update_in_progress }
+
+        it { is_expected.to be false }
+      end
+      
+      context 'when in a failed state' do
+        let(:stubbed_response) { update_failed }
+
+        it { is_expected.to be true }
+      end
+    end
+  end
+
+  describe '#transitive_states' do
+     subject { state.transitive_states }
+
+     it { is_expected.to include 'CREATE_IN_PROGRESS' }
+     it { is_expected.to include 'ROLLBACK_IN_PROGRESS' }
+     it { is_expected.to include 'DELETE_IN_PROGRESS' }
+     it { is_expected.to include 'CREATE_IN_PROGRESS' }
+     it { is_expected.to include 'UPDATE_COMPLETE_CLEANUP_IN_PROGRESS' }
+     it { is_expected.to include 'UPDATE_IN_PROGRESS' }
+     it { is_expected.to include 'UPDATE_ROLLBACK_IN_PROGRESS' }
+     it { is_expected.to include 'UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS' }
+
+     it { is_expected.not_to include 'CREATE_FAILED' }
+     it { is_expected.not_to include 'CREATE_COMPLETE' }
+     it { is_expected.not_to include 'ROLLBACK_FAILED' }
+     it { is_expected.not_to include 'ROLLBACK_COMPLETE' }
+     it { is_expected.not_to include 'UPDATE_COMPLETE' }
+     it { is_expected.not_to include 'UPDATE_ROLLBACK_FAILED' }
+     it { is_expected.not_to include 'UPDATE_ROLLBACK_COMPLETE' }
+     it { is_expected.not_to include 'DELETE_COMPLETE' }
+  end
+
+  describe '#finished_states' do
+     subject { state.finished_states }
+
+     it { is_expected.to include 'CREATE_COMPLETE' }
+     it { is_expected.to include 'UPDATE_COMPLETE' }
+     it { is_expected.to include 'DELETE_COMPLETE' }
+     it { is_expected.to include 'CREATE_FAILED' }
+     it { is_expected.to include 'ROLLBACK_FAILED' }
+     it { is_expected.to include 'ROLLBACK_COMPLETE' }
+     it { is_expected.to include 'UPDATE_ROLLBACK_FAILED' }
+     it { is_expected.to include 'UPDATE_ROLLBACK_COMPLETE' }
+
+     it { is_expected.not_to include 'CREATE_IN_PROGRESS' }
+     it { is_expected.not_to include 'ROLLBACK_IN_PROGRESS' }
+     it { is_expected.not_to include 'DELETE_IN_PROGRESS' }
+     it { is_expected.not_to include 'CREATE_IN_PROGRESS' }
+     it { is_expected.not_to include 'UPDATE_COMPLETE_CLEANUP_IN_PROGRESS' }
+     it { is_expected.not_to include 'UPDATE_IN_PROGRESS' }
+     it { is_expected.not_to include 'UPDATE_ROLLBACK_IN_PROGRESS' }
+     it { is_expected.not_to include 'UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS' }
+  end
+
+  describe '#success_states' do
+     subject { state.success_states }
+
+     it { is_expected.to include 'CREATE_COMPLETE' }
+     it { is_expected.to include 'UPDATE_COMPLETE' }
+     it { is_expected.to include 'DELETE_COMPLETE' }
+
+     it { is_expected.not_to include 'CREATE_IN_PROGRESS' }
+     it { is_expected.not_to include 'ROLLBACK_IN_PROGRESS' }
+     it { is_expected.not_to include 'DELETE_IN_PROGRESS' }
+     it { is_expected.not_to include 'CREATE_IN_PROGRESS' }
+     it { is_expected.not_to include 'UPDATE_COMPLETE_CLEANUP_IN_PROGRESS' }
+     it { is_expected.not_to include 'UPDATE_IN_PROGRESS' }
+     it { is_expected.not_to include 'UPDATE_ROLLBACK_IN_PROGRESS' }
+     it { is_expected.not_to include 'UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS' }
+     it { is_expected.not_to include 'CREATE_FAILED' }
+     it { is_expected.not_to include 'ROLLBACK_FAILED' }
+     it { is_expected.not_to include 'ROLLBACK_COMPLETE' }
+     it { is_expected.not_to include 'UPDATE_ROLLBACK_FAILED' }
+     it { is_expected.not_to include 'UPDATE_ROLLBACK_COMPLETE' }
+  end
+
+  describe '#failed_states' do
+     subject { state.failed_states }
+     
+     it { is_expected.to include 'ROLLBACK_FAILED' }
+     it { is_expected.to include 'ROLLBACK_COMPLETE' }
+     it { is_expected.to include 'UPDATE_ROLLBACK_FAILED' }
+     it { is_expected.to include 'UPDATE_ROLLBACK_COMPLETE' }
+     it { is_expected.to include 'CREATE_FAILED' }
+
+     it { is_expected.not_to include 'CREATE_COMPLETE' }
+     it { is_expected.not_to include 'UPDATE_COMPLETE' }
+     it { is_expected.not_to include 'DELETE_COMPLETE' }
+     it { is_expected.not_to include 'CREATE_IN_PROGRESS' }
+     it { is_expected.not_to include 'ROLLBACK_IN_PROGRESS' }
+     it { is_expected.not_to include 'DELETE_IN_PROGRESS' }
+     it { is_expected.not_to include 'CREATE_IN_PROGRESS' }
+     it { is_expected.not_to include 'UPDATE_COMPLETE_CLEANUP_IN_PROGRESS' }
+     it { is_expected.not_to include 'UPDATE_IN_PROGRESS' }
+     it { is_expected.not_to include 'UPDATE_ROLLBACK_IN_PROGRESS' }
+     it { is_expected.not_to include 'UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS' }
+  end
+end


### PR DESCRIPTION
Adds a new `events` command to the cli to list events from a stack.
This gets called by default after starting a stack creation/update to follow its execution