### PR TITLE
Track and display Child Stacks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.2
+  - 2.3.1
 sudo: false
 before_install:
   - gem install bundler -v '~> 1.10'

--- a/cfncli.gemspec
+++ b/cfncli.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "waiting", "~> 0"
   spec.add_dependency "activesupport", "~> 4"
   spec.add_dependency "colorize", "~> 0"
+  spec.add_dependency "concurrent-ruby", "~> 1.0"
 end

--- a/lib/cfncli/cloudformation.rb
+++ b/lib/cfncli/cloudformation.rb
@@ -43,9 +43,9 @@ module CfnCli
       logger.debug "Creating stack #{options['stack_name']}"
       stack = create_or_update_stack(options, config)
 
-      events(stack.stack_id, config)
+      events(stack, config)
       Waiting.wait(interval: config.interval || default_config.interval, max_attempts: config.retries || default_config.retries) do |waiter|
-        waiter.done if stack.finished?
+        waiter.done if stack.finished? && !stack.listing_events?
       end  
     end
 

--- a/lib/cfncli/cloudformation.rb
+++ b/lib/cfncli/cloudformation.rb
@@ -44,6 +44,9 @@ module CfnCli
       stack = create_or_update_stack(options, config)
 
       events(stack.stack_id, config)
+      Waiting.wait(interval: config.interval || default_config.interval, max_attempts: config.retries || default_config.retries) do |waiter|
+        waiter.done if stack.finished?
+      end  
     end
 
     # List stack events
@@ -83,6 +86,10 @@ module CfnCli
           parameter_value: param.first.last
         }
       end
+    end
+
+    def default_config
+      Config::CfnClient.new
     end
 
     private

--- a/lib/cfncli/event.rb
+++ b/lib/cfncli/event.rb
@@ -6,6 +6,9 @@ module CfnCli
 
     attr_reader :event
 
+    RESOURCE_CREATE_INITIATED = 'Resource creation Initiated'.freeze
+    AWS_STACK_RESOURCE = 'AWS::CloudFormation::Stack'.freeze
+
     def initialize(event)
       @event = event
     end
@@ -18,6 +21,14 @@ module CfnCli
       return :green if succeeded?
       return :yellow if in_progress?
       return :red if failed?
+    end
+
+    # Check if the current event has the signature of a child stack creation
+    def child_stack_create_event?
+      return false unless in_progress?
+      return false unless event.resource_type == AWS_STACK_RESOURCE
+      return false unless event.resource_status_reason == RESOURCE_CREATE_INITIATED
+      true
     end
 
     def to_s

--- a/lib/cfncli/event_poller.rb
+++ b/lib/cfncli/event_poller.rb
@@ -3,7 +3,9 @@ require 'cfncli/event'
 
 module CfnCli
   class EventPoller
-    def initialize
+    attr_reader :message_prefix
+    def initialize(message_prefix = nil)
+      @message_prefix = message_prefix
     end
 
     def event(event)
@@ -11,7 +13,12 @@ module CfnCli
     end
 
     def colorize(event)
-      puts event.to_s.colorize(event.color)
+      puts add_prefix(event.to_s).colorize(event.color)
+    end
+
+    def add_prefix(message)
+      message = "#{message_prefix} - #{message}" unless message_prefix.nil?
+      message
     end
   end
 end

--- a/lib/cfncli/event_poller.rb
+++ b/lib/cfncli/event_poller.rb
@@ -1,23 +1,26 @@
 require 'colorize'
 require 'cfncli/event'
+require 'thread'
 
 module CfnCli
   class EventPoller
-    attr_reader :message_prefix
-    def initialize(message_prefix = nil)
-      @message_prefix = message_prefix
+
+    def initialize
+      @mutex = Mutex.new
     end
 
-    def event(event)
-      colorize Event.new(event)
+    def event(event, prefix = nil)
+      colorize Event.new(event), prefix
     end
 
-    def colorize(event)
-      puts add_prefix(event.to_s).colorize(event.color)
+    def colorize(event, prefix = nil)
+      @mutex.synchronize do
+        puts add_prefix(event.to_s, prefix).colorize(event.color)
+      end
     end
 
-    def add_prefix(message)
-      message = "#{message_prefix} - #{message}" unless message_prefix.nil?
+    def add_prefix(message, prefix = nil)
+      message = "#{prefix} - #{message}" unless prefix.nil?
       message
     end
   end

--- a/lib/cfncli/event_streamer.rb
+++ b/lib/cfncli/event_streamer.rb
@@ -21,13 +21,14 @@ module CfnCli
     def each_event(&block)
       Waiting.wait(interval: config.interval, max_attempts: config.retries) do |waiter|
         list_events(&block)
-
         waiter.done if stack.finished?
       end
     end
 
     def list_events(&block)
-      @next_token = stack.events(@next_token).sort { |a, b| a.timestamp <=> b.timestamp }.each do |event|
+      events = []
+      @next_token = stack.events(@next_token).each { |event| events << event }
+      events.sort { |a, b| a.timestamp <=> b.timestamp }.each do |event|
         yield event unless seen?(event) if block_given?
       end
    end

--- a/lib/cfncli/event_streamer.rb
+++ b/lib/cfncli/event_streamer.rb
@@ -1,5 +1,7 @@
 module CfnCli
   class EventStreamer
+    require 'cfncli/config'
+
     attr_reader :stack
     attr_reader :config
 
@@ -25,7 +27,7 @@ module CfnCli
     end
 
     def list_events(&block)
-      @next_token = stack.events(@next_token).each do |event|
+      @next_token = stack.events(@next_token).sort { |a, b| a.timestamp <=> b.timestamp }.each do |event|
         yield event unless seen?(event) if block_given?
       end
    end

--- a/lib/cfncli/stack.rb
+++ b/lib/cfncli/stack.rb
@@ -93,7 +93,7 @@ module CfnCli
     # List all events in real time
     # @param poller [CfnCli::Poller] Poller class to display events
     def list_events(poller, streamer = nil, config = nil, event_prefix = nil)
-      Thread.new do
+      @event_listing_thread = Thread.new do
         streamer ||= EventStreamer.new(self, config)
         streamer.each_event do |event|
           if Event.new(event).child_stack_create_event?
@@ -109,10 +109,15 @@ module CfnCli
       stack.events(next_token)
     end
 
+    # Is this stack currently listing events
+    def listing_events?
+      !@event_listing_thread.nil? && @event_listing_thread.alive?
+    end
+
     # Indicates if the stack is in a finished state
     def finished?
       return false if stack.nil?
-      finished_states.include? stack.stack_status
+      finished_states.include?(stack.stack_status)
     end
 
     # Indicates if the stack is in a successful state

--- a/lib/cfncli/stack.rb
+++ b/lib/cfncli/stack.rb
@@ -2,6 +2,7 @@ require 'cfncli/cfn_client'
 require 'cfncli/logger'
 require 'cfncli/config'
 require 'cfncli/event_streamer'
+require 'cfncli/event'
 require 'cfncli/states'
 
 require 'waiting'

--- a/spec/lib/cfncli/event_spec.rb
+++ b/spec/lib/cfncli/event_spec.rb
@@ -33,4 +33,58 @@ describe CfnCli::Event do
       it { is_expected.to be :red }
     end
   end
+
+  describe '#child_stack_create_event?' do
+    subject { event.child_stack_create_event? }
+    before do
+      event.instance_variable_set :@event, event_obj
+    end
+    context 'when event is a child stack creation event' do
+      let(:event_obj) { double('AWS::CloudFormation::Event') }
+      let(:resource_type) { 'AWS::CloudFormation::Stack' }
+      let(:status_reason) { 'Resource creation Initiated' }
+      before do
+        expect(event).to receive(:in_progress?).and_return true
+        expect(event_obj).to receive(:resource_type).and_return resource_type
+        expect(event_obj).to receive(:resource_status_reason).and_return status_reason
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context 'when event is not a child stack creation event' do
+      let(:event_obj) { double('AWS::CloudFormation::Event') }
+      context 'when event is not in progress' do
+        before do
+          expect(event).to receive(:in_progress?).and_return false
+        end
+
+        it { is_expected.to be false }
+      end
+
+      context 'when resource type is not a stack' do
+        let(:event_obj) { double('AWS::CloudFormation::Event') }
+        let(:resource_type) { 'AWS::AutoScaling::AutoScalingGroup' }
+        before do
+          expect(event).to receive(:in_progress?).and_return true
+          expect(event_obj).to receive(:resource_type).and_return resource_type
+        end
+
+        it { is_expected.to be false }
+      end
+
+      context 'when status reason is not creation initiated' do
+        let(:event_obj) { double('AWS::CloudFormation::Event') }
+        let(:resource_type) { 'AWS::CloudFormation::Stack' }
+        let(:status_reason) { 'Received SUCCESS signal' }
+        before do
+          expect(event).to receive(:in_progress?).and_return true
+          expect(event_obj).to receive(:resource_type).and_return resource_type
+          expect(event_obj).to receive(:resource_status_reason).and_return status_reason
+        end
+
+        it { is_expected.to be false }
+      end
+    end
+  end
 end

--- a/spec/lib/cfncli/event_streamer_spec.rb
+++ b/spec/lib/cfncli/event_streamer_spec.rb
@@ -1,4 +1,5 @@
 require 'cfncli/event_streamer'
+require 'cfncli/event'
 
 describe CfnCli::EventStreamer do
   subject(:streamer) { CfnCli::EventStreamer.new(nil) }

--- a/spec/lib/cfncli/stack_spec.rb
+++ b/spec/lib/cfncli/stack_spec.rb
@@ -211,9 +211,12 @@ describe CfnCli::Stack do
       allow(streamer).to receive(:each_event) do |&block|
         block.call(test_event)
       end
-      allow(poller).to receive(:event).with test_event
+      allow(poller).to receive(:event).with test_event, nil
       allow(CfnCli::Event).to receive(:new).with(test_event).and_return cli_event
       allow(cli_event).to receive(:child_stack_create_event?).and_return false
+      allow(Thread).to receive(:new) do |&block|
+        block.call
+      end
     end
 
     it 'passes a block to each_event for streaming' do
@@ -228,12 +231,12 @@ describe CfnCli::Stack do
         expect(test_event).to receive(:physical_resource_id).and_return resource_id
         expect(test_event).to receive(:logical_resource_id).and_return logical_id
         expect(cli_event).to receive(:child_stack_create_event?).and_return true
-        expect(subject).to receive(:track_child_stack).with resource_id, logical_id
+        expect(subject).to receive(:track_child_stack).with resource_id, logical_id, poller
         subject.list_events poller, streamer
       end
 
       it 'sends the event to the poller' do
-        expect(poller).to receive(:event).with test_event
+        expect(poller).to receive(:event).with test_event, nil
         subject.list_events poller, streamer
       end
     end


### PR DESCRIPTION
With these changes any child stack that is created will automatically be tracked and its events logged with the child stacks logical id used as a prefix i.e
```
child-stack-1 <normal event message>
```

Closes #6 