### PR TITLE
Add an option to sync stdout

### DIFF
--- a/lib/cfncli/cli.rb
+++ b/lib/cfncli/cli.rb
@@ -29,6 +29,12 @@ module CfnCli
                   default: 'cfncli.yml',
                   desc: 'Configuration file'
 
+    class_option 'sync_stdout',
+                 type: :boolean,
+                 default: true,
+                 desc: 'Force stdout to be flushed everytime. Useful to update logs in real time when running in CI'
+
+
     # Stack options
     method_option 'stack_name',
                   alias: '-n',
@@ -256,6 +262,9 @@ module CfnCli
         check_exclusivity(opts.keys, ['disable_rollback', 'on_failure'])
         check_exclusivity(opts.keys, ['stack_policy_body', 'stack_policy_url'])
         check_exclusivity(opts.keys, ['parameters', 'parameters_file'])
+
+        sync_stdout = consume_option(opts, 'sync_stdout')
+        $stdout.sync = sync_stdout
 
         opts['template_body'] = file_or_content(opts['template_body']) if opts['template_body']
         opts['stack_policy_body'] = file_or_content(opts['stack_policy_body']) if opts['stack_policy_body']


### PR DESCRIPTION
When output is not stdout, it gets fully buffered instead of line buffered.
This PR adds an option (on by default) to force stdout to be flushed everytime something is written.

This makes it much better to view live logs from CI or a tail -f