### PR TITLE
Add `use_previous_template` option; Fix stack tagging

### DIFF
--- a/lib/cfncli/cli.rb
+++ b/lib/cfncli/cli.rb
@@ -100,6 +100,7 @@ module CfnCli
 
     method_option 'tags',
                   type: :hash,
+                  lazy_default: {},
                   desc: 'Key-value pairs to associate with this stack'
 
     # Application options
@@ -272,6 +273,7 @@ module CfnCli
         $stdout.sync = sync_stdout
 
         opts['template_body'] = file_or_content(opts['template_body']) if opts['template_body']
+        opts['tags'] = process_stack_tags(opts['tags']) if opts['tags']
         opts['stack_policy_body'] = file_or_content(opts['stack_policy_body']) if opts['stack_policy_body']
         opts['parameters'] = process_stack_parameters(opts['parameters']) if opts['parameters']
         opts['parameters'] = process_stack_parameters_file(consume_option(opts, 'parameters_file')) if opts['parameters_file']
@@ -330,6 +332,16 @@ module CfnCli
             parameter_value: value
           }
         end
+      end
+
+      def process_stack_tags(tags)
+        return [] unless tags
+
+        real_tags = []
+        tags.each do |key, value|
+          real_tags << { key: key, value: value }
+        end
+        real_tags
       end
 
       # Cloudformation utility object

--- a/lib/cfncli/cli.rb
+++ b/lib/cfncli/cli.rb
@@ -52,6 +52,11 @@ module CfnCli
                   desc: 'S3 URL to the Cloudformation template.' \
                         ' This is exclusive with the template_body option'
 
+    method_option 'use_previous_template',
+                  type: :boolean,
+                  desc: 'Reuse the existing template that is associated with ' \
+                        'the stack that you are updating.'
+
     method_option 'parameters',
                   type: :hash,
                   desc: 'Stack parameters. Pass each parameter in the form --parameters key1:value1 key2:value2 or use the @filename syntax to provide a JSON file'


### PR DESCRIPTION
The `use_previous_template` option allows updating a stack without specifying the template to use.

Currently tagging does not work, this fixes it so that passing `--tags test:hello test2:goodbye` will create the correct tags, and passing `--tags` with no values will remove all tags from the stack

CC @lethalpaga 