### PR TITLE
Optionally list nested events

### DIFF
--- a/lib/cfncli/cli.rb
+++ b/lib/cfncli/cli.rb
@@ -110,6 +110,11 @@ module CfnCli
                   default: true,
                   desc: 'List the stack events during the operation'
 
+    method_option 'list_nested_events',
+                  type: :boolean,
+                  default: true,
+                  desc: 'List events from nested stacks'
+
     method_option 'interval',
                   type: :numeric,
                   default: 10,
@@ -172,6 +177,11 @@ module CfnCli
                   desc: 'Name or ID of the Cloudformation stack'
 
     # Application options.
+    method_option 'list_nested_events',
+                  type: :boolean,
+                  default: true,
+                  desc: 'List events from nested stacks'
+
     method_option 'interval',
                   type: :numeric,
                   default: 10,
@@ -194,7 +204,7 @@ module CfnCli
       fail ArgumentError, 'stack_name is required' unless stack_name
 
       config = Config::CfnClient.new(options['interval'], options['retries'], options['retry_limit'])
-      cfn.events(stack_name, config)
+      cfn.events(stack_name, config, options['list_nested_events'])
     end
 
     method_option 'stack_name',

--- a/lib/cfncli/cloudformation.rb
+++ b/lib/cfncli/cloudformation.rb
@@ -41,16 +41,18 @@ module CfnCli
     def apply_and_list_events(options, config = nil)
       # Create/update the stack
       logger.debug "Creating stack #{options['stack_name']}"
+      list_nested_events = options['list_nested_events']
+      options.delete 'list_nested_events'
       stack = create_or_update_stack(options, config)
 
-      events(stack, config)
+      events(stack, config, list_nested_events)
       Waiting.wait(interval: config.interval || default_config.interval, max_attempts: config.retries || default_config.retries) do |waiter|
         waiter.done if stack.finished? && !stack.listing_events?
-      end  
+      end
     end
 
     # List stack events
-    def events(stack_or_name, config = nil, reset_events = true, poller = nil, streamer = nil)
+    def events(stack_or_name, config = nil, list_nested_events = true, reset_events = true, poller = nil, streamer = nil)
       stack = stack_or_name
       stack = create_stack_obj(stack_or_name, config) unless stack_or_name.is_a? CfnCli::Stack
 
@@ -60,7 +62,7 @@ module CfnCli
       streamer.reset_events if reset_events
 
       logger.debug "Listing events for stack #{stack.stack_name}"
-      stack.list_events(poller, streamer, config)
+      stack.list_events(poller, streamer, config, nil, list_nested_events)
     end
 
     # Delete a stack

--- a/lib/cfncli/stack.rb
+++ b/lib/cfncli/stack.rb
@@ -95,11 +95,11 @@ module CfnCli
 
     # List all events in real time
     # @param poller [CfnCli::Poller] Poller class to display events
-    def list_events(poller, streamer = nil, config = nil, event_prefix = nil)
+    def list_events(poller, streamer = nil, config = nil, event_prefix = nil, list_nested_events = true)
       @event_listing_thread = Thread.new do
         streamer ||= EventStreamer.new(self, config)
         streamer.each_event do |event|
-          if Event.new(event).child_stack_create_event?
+          if list_nested_events && Event.new(event).child_stack_create_event?
             track_child_stack(event.physical_resource_id, event.logical_resource_id, poller)
           end
           poller.event(event, event_prefix)

--- a/spec/lib/cfncli/stack_spec.rb
+++ b/spec/lib/cfncli/stack_spec.rb
@@ -227,12 +227,25 @@ describe CfnCli::Stack do
     context 'each_event block' do
       let(:resource_id) { 'FAKE_ID' }
       let(:logical_id) { 'TEST_ID' }
-      it 'detects and tracks child stacks if event is a child stack creation' do
-        expect(test_event).to receive(:physical_resource_id).and_return resource_id
-        expect(test_event).to receive(:logical_resource_id).and_return logical_id
-        expect(cli_event).to receive(:child_stack_create_event?).and_return true
-        expect(subject).to receive(:track_child_stack).with resource_id, logical_id, poller
-        subject.list_events poller, streamer
+
+      context 'when list_nested_events is true' do
+        it 'detects and tracks child stacks if event is a child stack creation' do
+          expect(test_event).to receive(:physical_resource_id).and_return resource_id
+          expect(test_event).to receive(:logical_resource_id).and_return logical_id
+          expect(cli_event).to receive(:child_stack_create_event?).and_return true
+          expect(subject).to receive(:track_child_stack).with resource_id, logical_id, poller
+          subject.list_events poller, streamer
+        end
+      end
+
+      context 'when list_nested_events is false' do
+        it 'does not detect and track child stacks if event is a child stack creation' do
+          expect(test_event).not_to receive(:physical_resource_id)
+          expect(test_event).not_to receive(:logical_resource_id)
+          expect(cli_event).not_to receive(:child_stack_create_event?)
+          expect(subject).not_to receive(:track_child_stack)
+          subject.list_events poller, streamer, nil, nil, false
+        end
       end
 
       it 'sends the event to the poller' do


### PR DESCRIPTION
Currently listing nested events is forced. This makes it a cli argument that defaults to true. The reasoning behind this is that a stack with many nested stacks will start to hit the API rate limit when trying to describe all of the nested stacks