### PR TITLE
Remove options that only apply on create before calling update

### DIFF
--- a/lib/cfncli/cloudformation.rb
+++ b/lib/cfncli/cloudformation.rb
@@ -11,6 +11,9 @@ module CfnCli
     include CfnClient
     include Loggable
 
+    # A list of options that only apply for stack creation
+    CREATE_ONLY_OPTIONS = %w(on_failure).freeze
+
     def initialize
     end
 
@@ -29,6 +32,7 @@ module CfnCli
       stack = create_stack_obj(stack_name, config)
 
       if stack.exists?
+        CREATE_ONLY_OPTIONS.each { |key| opts.delete key }
         stack.update(opts)
       else
         stack.create(opts)
@@ -46,7 +50,7 @@ module CfnCli
       events(stack, config)
       Waiting.wait(interval: config.interval || default_config.interval, max_attempts: config.retries || default_config.retries) do |waiter|
         waiter.done if stack.finished? && !stack.listing_events?
-      end  
+      end
     end
 
     # List stack events

--- a/spec/lib/cfncli/cloudformation_spec.rb
+++ b/spec/lib/cfncli/cloudformation_spec.rb
@@ -9,7 +9,8 @@ describe CfnCli::CloudFormation do
   end
 
   describe '#create_or_update_stack' do
-    subject { cfn.create_or_update_stack({}) }
+    let(:opts) { Hash.new }
+    subject { cfn.create_or_update_stack(opts) }
 
     let(:stack) { double CfnCli::Stack }
 
@@ -21,7 +22,7 @@ describe CfnCli::CloudFormation do
     context 'when the stack does not exist' do
       let(:exists) { false }
       it 'is expected to call stack.create' do
-        expect(stack).to receive(:create).with({})
+        expect(stack).to receive(:create).with(opts)
         subject
       end
     end
@@ -29,12 +30,19 @@ describe CfnCli::CloudFormation do
     context 'when the stack exists' do
       let(:exists) { true }
       it 'is expected to call stack.update' do
-        expect(stack).to receive(:update).with({})
+        expect(stack).to receive(:update).with(opts)
         subject
+      end
+      context 'and the opts contain create only options' do
+        let(:opts) { { 'stack_name' => 'test', 'on_failure' => 'DELETE' } }
+        it 'strips out options that are only supported on create' do
+          expect(stack).to receive(:update).with('stack_name' => 'test')
+          subject
+        end
       end
     end
   end
-  
+
   describe '#delete_stack' do
     subject { cfn.delete_stack('stack_name', {}) }
 


### PR DESCRIPTION
Currently if you call `apply` with the `--on-failure` option set it will work as expected if the stack doesn't exist, but when the stack does exist it will fail when the Aws `param_validator` find the unexpected `on_failure` attribute