### PR TITLE
Never fail on rate limiting

### DIFF
--- a/lib/cfncli/event_streamer.rb
+++ b/lib/cfncli/event_streamer.rb
@@ -31,7 +31,9 @@ module CfnCli
       events.sort { |a, b| a.timestamp <=> b.timestamp }.each do |event|
         yield event unless seen?(event) if block_given?
       end
-   end
+    rescue Aws::CloudFormation::Errors::ServiceError => e
+      raise unless e.class.name == 'Aws::CloudFormation::Errors::Throttling'
+    end
 
     # Mark all the existing events as 'seen'
     def reset_events


### PR DESCRIPTION
Catches all rate limiting exceptions and takes no action. This should prevent rate limiting errors from causing breakages.

If they occur repeatedly they will eventually go over the maximum attempts for the waiter