### PR TITLE
Upgrade to AWS SDK V3

### DIFF
--- a/cfncli.gemspec
+++ b/cfncli.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "guard-rspec"
  
   spec.add_dependency "thor"
-  spec.add_dependency "aws-sdk", "~> 2"
+  spec.add_dependency "aws-sdk-cloudformation", "~> 1"
   spec.add_dependency "waiting", "~> 0"
   spec.add_dependency "activesupport", ">= 4", "< 6"
   spec.add_dependency "colorize", "~> 0"

--- a/lib/cfncli/cfn_client.rb
+++ b/lib/cfncli/cfn_client.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-cloudformation'
 
 module CfnCli
   module CfnClient

--- a/lib/cfncli/cli.rb
+++ b/lib/cfncli/cli.rb
@@ -1,5 +1,5 @@
 require 'thor'
-require 'aws-sdk'
+require 'aws-sdk-cloudformation'
 
 require 'cfncli/cloudformation'
 require 'cfncli/config'

--- a/lib/cfncli/event_streamer.rb
+++ b/lib/cfncli/event_streamer.rb
@@ -1,3 +1,5 @@
+require 'aws-sdk-cloudformation'
+
 module CfnCli
   class EventStreamer
     require 'cfncli/config'

--- a/lib/cfncli/stack.rb
+++ b/lib/cfncli/stack.rb
@@ -7,6 +7,7 @@ require 'cfncli/states'
 require 'thread'
 require 'concurrent/array'
 require 'waiting'
+require 'aws-sdk-cloudformation'
 
 module CfnCli
   class Stack

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 #require "codeclimate-test-reporter"
 #CodeClimate::TestReporter.start
 
-require 'aws-sdk'
+require 'aws-sdk-cloudformation'
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
 require 'rspec/its'


### PR DESCRIPTION
Uses the new V3 aws sdk which has broken out each service into it's own gem.

I can include a version bump if you'd like, it should probably be a major version as anything else could break dependent projects that also use sdk v2