### PR TITLE
Parse parameters in format specified by CloudFormation

### DIFF
--- a/lib/cfncli/cli.rb
+++ b/lib/cfncli/cli.rb
@@ -354,10 +354,10 @@ module CfnCli
         return file_or_content(parameters) if file_param? parameters
 
         # Otherwise convert each param to the cfn structure
-        parameters.map do |key, value|
+        parameters.map do |param|
           {
-            parameter_key: key,
-            parameter_value: value
+            parameter_key: param['ParameterKey'],
+            parameter_value: param['ParameterValue']
           }
         end
       end

--- a/lib/cfncli/cloudformation.rb
+++ b/lib/cfncli/cloudformation.rb
@@ -109,8 +109,8 @@ module CfnCli
     def self.parse_json_params(params)
       params.map do |param|
         {
-          parameter_key: param.first.first,
-          parameter_value: param.first.last
+          parameter_key: param['ParameterKey'],
+          parameter_value: param['ParameterValue']
         }
       end
     end

--- a/lib/cfncli/version.rb
+++ b/lib/cfncli/version.rb
@@ -1,3 +1,3 @@
 module CfnCli
-  VERSION = "0.9.1"
+  VERSION = "1.0.0"
 end

--- a/spec/lib/cfncli/cli_spec.rb
+++ b/spec/lib/cfncli/cli_spec.rb
@@ -58,10 +58,16 @@ describe CfnCli::Cli do
     subject { cli.process_stack_parameters(params) }
 
     let(:params) do
-      {
-        opt1: 'val1',
-        opt2: 'val2'
-      }
+      [
+        {
+          'ParameterKey' => :opt1,
+          'ParameterValue' => 'val1'
+        },
+        {
+          'ParameterKey' => :opt2,
+          'ParameterValue' => 'val2'
+        }
+      ]
     end
 
     let(:expected_result) do


### PR DESCRIPTION
closes #4 

The documentation implies that the format should match the CloudFormation specification from [here](https://aws.amazon.com/blogs/devops/passing-parameters-to-cloudformation-stacks-with-the-aws-cli-and-powershell/), so now it does.