### PR TITLE
Use correct parameter syntax for CLI params

### DIFF
--- a/lib/cfncli/cli.rb
+++ b/lib/cfncli/cli.rb
@@ -371,16 +371,16 @@ module CfnCli
         validation_failures = []
         parsed_params = params.map.with_index do |param, i|
           key, value = param.split(',', 2)
-          if key.nil? || value.nil?
-            validations << "- Parameter[#{i}] format invalid: #{param}"
+          if key.to_s.empty? || value.to_s.empty?
+            validation_failures << "- Parameter[#{i}] format invalid: #{param}"
             next
           end
           param_key_key, param_key_value = key.split('=', 2)
           param_value_key, param_value_value = value.split('=', 2)
           validation_failures << "- Parameter[#{i}] missing ParameterKey key: #{param}" unless param_key_key.downcase == 'parameterkey'
-          validation_failures << "- Parameter[#{i}] missing ParameterKey value: #{param}" if param_key_value.nil?
+          validation_failures << "- Parameter[#{i}] missing ParameterKey value: #{param}" if param_key_value.to_s.empty?
           validation_failures << "- Parameter[#{i}] missing ParameterValue key: #{param}" unless param_value_key.downcase == 'parametervalue'
-          validation_failures << "- Parameter[#{i}] missing ParameterValue value: #{param}" if param_value_value.nil?
+          validation_failures << "- Parameter[#{i}] missing ParameterValue value: #{param}" if param_value_value.to_s.empty?
           {
             parameter_key: param_key_value,
             parameter_value: param_value_value

--- a/lib/cfncli/version.rb
+++ b/lib/cfncli/version.rb
@@ -1,3 +1,3 @@
 module CfnCli
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/spec/lib/cfncli/cli_spec.rb
+++ b/spec/lib/cfncli/cli_spec.rb
@@ -57,14 +57,15 @@ describe CfnCli::Cli do
   describe '#process_stack_parameters' do
     subject { cli.process_stack_parameters(params) }
 
-    let(:params) do
-      [
-        "ParameterKey=opt1,ParameterValue=val1",
-        "ParameterKey=opt2,ParameterValue=val2"
-      ]
-    end
+    context 'when the parameters are valid' do
+      let(:params) do
+        [
+          "ParameterKey=opt1,ParameterValue=val1",
+          "ParameterKey=opt2,ParameterValue=val2"
+        ]
+      end
 
-    let(:expected_result) do
+      let(:expected_result) do
       [
         {
           parameter_key: "opt1",
@@ -75,8 +76,67 @@ describe CfnCli::Cli do
           parameter_value: 'val2'
         }
       ]
+      end
+
+      it { is_expected.to eq expected_result }
     end
 
-    it { is_expected.to eq expected_result }
+    context 'when the parameters are invalid' do
+      context 'because the format is invalid' do
+        let(:params) do
+          [
+            "notvalid:string"
+          ]
+        end
+
+        it 'raises a validation error' do
+          expect { subject }.to raise_error(/Parameter\[0\] format invalid/)
+        end
+      end
+      context 'because the ParameterKey key is incorrect' do
+        let(:params) do
+          [
+            "NotKey:MyKeyName,ParameterValue=MyKeyValue"
+          ]
+        end
+
+        it 'raises a validation error' do
+          expect { subject }.to raise_error(/Parameter\[0\] missing ParameterKey key/)
+        end
+      end
+      context 'because the ParameterKey value is missing' do
+        let(:params) do
+          [
+            "ParameterKey=,ParameterValue=MyKeyValue"
+          ]
+        end
+
+        it 'raises a validation error' do
+          expect { subject }.to raise_error(/Parameter\[0\] missing ParameterKey value/)
+        end
+      end
+      context 'because the ParameterValue key is incorrect' do
+        let(:params) do
+          [
+            "ParameterKey=MyKeyName,NotValueKey=MyKeyValue"
+          ]
+        end
+
+        it 'raises a validation error' do
+          expect { subject }.to raise_error(/Parameter\[0\] missing ParameterValue key/)
+        end
+      end
+      context 'because the ParameterValue value is missing' do
+        let(:params) do
+          [
+            "ParameterKey=MyKeyName,ParameterValue="
+          ]
+        end
+
+        it 'raises a validation error' do
+          expect { subject }.to raise_error(/Parameter\[0\] missing ParameterValue value/)
+        end
+      end
+    end
   end
 end

--- a/spec/lib/cfncli/cli_spec.rb
+++ b/spec/lib/cfncli/cli_spec.rb
@@ -59,25 +59,19 @@ describe CfnCli::Cli do
 
     let(:params) do
       [
-        {
-          'ParameterKey' => :opt1,
-          'ParameterValue' => 'val1'
-        },
-        {
-          'ParameterKey' => :opt2,
-          'ParameterValue' => 'val2'
-        }
+        "ParameterKey=opt1,ParameterValue=val1",
+        "ParameterKey=opt2,ParameterValue=val2"
       ]
     end
 
     let(:expected_result) do
       [
         {
-          parameter_key: :opt1,
+          parameter_key: "opt1",
           parameter_value: 'val1'
         },
         {
-          parameter_key: :opt2,
+          parameter_key: "opt2",
           parameter_value: 'val2'
         }
       ]


### PR DESCRIPTION
#23 was supposed to make both file and cli parameter parsing follow the AWS specification. CLI was missed. This makes it follow the spec linked in the #23