### PR TITLE
Fix failure on listing events

### DIFF
--- a/lib/cfncli/stack.rb
+++ b/lib/cfncli/stack.rb
@@ -109,8 +109,8 @@ module CfnCli
     end
 
     # Get the events from the cfn stack
-    def events(next_token)
-      stack.events(next_token)
+    def events(next_token = nil)
+      stack.events(next_token: next_token)
     end
 
     # Is this stack currently listing events

--- a/lib/cfncli/version.rb
+++ b/lib/cfncli/version.rb
@@ -1,3 +1,3 @@
 module CfnCli
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end

--- a/spec/lib/cfncli/stack_spec.rb
+++ b/spec/lib/cfncli/stack_spec.rb
@@ -202,6 +202,29 @@ describe CfnCli::Stack do
     end
   end
 
+
+  describe '#events' do
+    let(:event) do
+      {
+        event_id: '2',
+        stack_id: stack.stack_id,
+        stack_name: stack.stack_name,
+        timestamp: Time.now
+      }
+    end
+
+    before do
+      client.stub_responses :describe_stack_events, {
+        stack_events: [
+          event
+        ]
+      }
+    end
+    it 'returns the stack events' do
+      expect(stack.events.first.event_id).to eq(event[:event_id])
+    end
+  end
+
   describe '#list_events' do
     let(:streamer) { double('CfnCli::EventStreamer') }
     let(:poller) { double('CfnCli::EventPoller') }


### PR DESCRIPTION
It seems the interface for listing events using the resource so that it takes a hash now.

This resulted in an error similar to:
```ruby
	from /home/teamcity/.rvm/gems/ruby-2.3.1/gems/aws-sdk-core-3.17.1/lib/aws-sdk-core/resources/collection.rb:99:in `each'
	from /home/teamcity/.rvm/gems/ruby-2.3.1/gems/aws-sdk-core-3.17.1/lib/aws-sdk-core/resources/collection.rb:99:in `each'
	from /home/teamcity/.rvm/gems/ruby-2.3.1/gems/aws-sdk-core-3.17.1/lib/aws-sdk-core/resources/collection.rb:99:in `block in non_empty_batches'
	from /home/teamcity/.rvm/gems/ruby-2.3.1/gems/aws-sdk-core-3.17.1/lib/aws-sdk-core/resources/collection.rb:50:in `each'
	from /home/teamcity/.rvm/gems/ruby-2.3.1/gems/aws-sdk-core-3.17.1/lib/aws-sdk-core/resources/collection.rb:50:in `each'
	from /home/teamcity/.rvm/gems/ruby-2.3.1/gems/aws-sdk-core-3.17.1/lib/aws-sdk-core/resources/collection.rb:50:in `block in each'
	from /home/teamcity/.rvm/gems/ruby-2.3.1/gems/aws-sdk-core-3.17.1/lib/aws-sdk-core/resources/collection.rb:56:in `each'
	from /home/teamcity/.rvm/gems/ruby-2.3.1/gems/aws-sdk-core-3.17.1/lib/aws-sdk-core/resources/collection.rb:56:in `each'
	from /home/teamcity/.rvm/gems/ruby-2.3.1/gems/aws-sdk-core-3.17.1/lib/aws-sdk-core/resources/collection.rb:56:in `each'
	from /home/teamcity/.rvm/gems/ruby-2.3.1/gems/cfncli-1.0.1/lib/cfncli/event_streamer.rb:32:in `list_events'
	from /home/teamcity/.rvm/gems/ruby-2.3.1/gems/cfncli-1.0.1/lib/cfncli/event_streamer.rb:42:in `reset_events'
	from /home/teamcity/.rvm/gems/ruby-2.3.1/gems/cfncli-1.0.1/lib/cfncli/cloudformation.rb:68:in `events'
	from /home/teamcity/.rvm/gems/ruby-2.3.1/gems/cfncli-1.0.1/lib/cfncli/cloudformation.rb:52:in `apply_and_list_events'
	from /home/teamcity/.rvm/gems/ruby-2.3.1/gems/cfncli-1.0.1/lib/cfncli/cli.rb:161:in `apply'
	from /home/teamcity/.rvm/gems/ruby-2.3.1@global/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
	from /home/teamcity/.rvm/gems/ruby-2.3.1@global/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
	from /home/teamcity/.rvm/gems/ruby-2.3.1@global/gems/thor-0.20.0/lib/thor.rb:387:in `dispatch'
	from /home/teamcity/.rvm/gems/ruby-2.3.1@global/gems/thor-0.20.0/lib/thor/base.rb:466:in `start'
	from /home/teamcity/.rvm/gems/ruby-2.3.1/gems/cfncli-1.0.1/exe/cfncli:4:in `<top (required)>'
	from /home/teamcity/.rvm/gems/ruby-2.3.1/bin/cfncli:23:in `load'
	from /home/teamcity/.rvm/gems/ruby-2.3.1/bin/cfncli:23:in `<main>'
```