### PR TITLE
Remove next_token when streaming events

### DIFF
--- a/lib/cfncli/event_streamer.rb
+++ b/lib/cfncli/event_streamer.rb
@@ -29,12 +29,12 @@ module CfnCli
 
     def list_events(&block)
       events = []
-      @next_token = stack.events(@next_token).each { |event| events << event }
+      stack.events.each { |event| events << event }
       events.sort { |a, b| a.timestamp <=> b.timestamp }.each do |event|
         yield event unless seen?(event) if block_given?
       end
-    rescue Aws::CloudFormation::Errors::ServiceError => e
-      raise unless e.class.name == 'Aws::CloudFormation::Errors::Throttling'
+    rescue Aws::CloudFormation::Errors::Throttling => e
+      # Ignoring throttling limit
     end
 
     # Mark all the existing events as 'seen'

--- a/lib/cfncli/stack.rb
+++ b/lib/cfncli/stack.rb
@@ -109,8 +109,8 @@ module CfnCli
     end
 
     # Get the events from the cfn stack
-    def events(next_token = nil)
-      stack.events(next_token: next_token)
+    def events
+      stack.events
     end
 
     # Is this stack currently listing events

--- a/lib/cfncli/version.rb
+++ b/lib/cfncli/version.rb
@@ -1,3 +1,3 @@
 module CfnCli
-  VERSION = "1.0.2"
+  VERSION = "1.0.3"
 end


### PR DESCRIPTION
It would seem in AWS SDK V3 the `#each` method of a Collection no longer returns a next_token. So we will just have to list all events all the time :(